### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,55 +1,42 @@
 {
-
-	"name":        "grunt-fp-phpacker",
-	"version":     "0.1.1",
+	"name": "grunt-fp-phpacker",
+	"version": "0.1.1",
 	"description": "Grunt plugin for PHP bundling",
-	"homepage":    "https://github.com/Proxmiff/grunt-fp-phpacker",
-
+	"homepage": "https://github.com/Proxmiff/grunt-fp-phpacker",
 	"author": {
-
-		"url":   "http://www.mousp.com/",
-		"name":  "MousP Softworx",
+		"url": "http://www.mousp.com/",
+		"name": "MousP Softworx",
 		"email": "info@mousp.com"
-
 	},
-
 	"licenses": [
 		{
-			"url":  "",
+			"url": "",
 			"type": "MIT"
 		}
 	],
-
 	"engines": {
 		"node": ">=0.8.21"
 	},
-
 	"repository": {
-		"url":  "git://github.com/Proxmiff/grunt-fp-phpacker.git",
+		"url": "git://github.com/Proxmiff/grunt-fp-phpacker.git",
 		"type": "git"
 	},
-
 	"bugs": {
 		"url": "https://github.com/Proxmiff/grunt-fp-phpacker/issues"
 	},
- 
 	"keywords": [
 		"gruntplugin"
 	],
-
 	"devDependencies": {
-		"grunt":                  "~0.4.0",
-		"grunt-contrib-nodeunit": "~0.2.0", 
-		"grunt-contrib-jshint":   "~0.6.0",
-		"grunt-contrib-clean":    "~0.4.0"
+		"grunt": "~0.4.0",
+		"grunt-contrib-nodeunit": "~0.2.0",
+		"grunt-contrib-jshint": "~0.6.0",
+		"grunt-contrib-clean": "~0.4.0"
 	},
- 
 	"peerDependencies": {
-		"grunt": "~0.4.0"
+		"grunt": ">=0.4.0"
 	},
-
 	"scripts": {
 		"test": "grunt test"
 	}
-
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
